### PR TITLE
Rename S3 bucket for clarity in configuration

### DIFF
--- a/aws-resources/aws-simple-plans/simple_s3.tf
+++ b/aws-resources/aws-simple-plans/simple_s3.tf
@@ -15,7 +15,7 @@ provider "aws" {
 
 resource "aws_s3_bucket" "example" {
   count = 10
-  bucket = "alfiia-s3-${count.index}-simple-${replace(time_static.now.unix, "/[^0-9]/", "")}"
+  bucket = "edited-for-checks-alfiia-s3-${count.index}-simple-${replace(time_static.now.unix, "/[^0-9]/", "")}"
   force_destroy = true
 
   tags = {


### PR DESCRIPTION
This pull request makes a minor update to the naming convention for S3 buckets in the `aws-simple-plans` Terraform configuration. The change prepends a prefix to the bucket names, likely to facilitate checks or environment-specific identification.

- Updated the `bucket` name in the `aws_s3_bucket.example` resource to include the prefix `edited-for-checks-` for all created S3 buckets.